### PR TITLE
Update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,13 +27,6 @@ on:
     - cron: "0 3 * * 6"
   push:
     branches:
-      - e66ac2-dev
-      - 950003-dev
-      - 950003-test
-      - 950003-prod
-  pull_request:
-    branches:
-      - e66ac2-dev
       - 950003-dev
       - 950003-test
       - 950003-prod


### PR DESCRIPTION
Removed (impossible) attempted deployments from feature or other branches which cannot be deployed. This is causing "errors" and unnecessary clutter in the actions log.

Also removed e66ac2-dev as a potential target branch, as the namespace has been deleted from OpenShift.